### PR TITLE
Fix unicode handling bug when formatting code

### DIFF
--- a/apps/els_core/src/els_protocol.erl
+++ b/apps/els_core/src/els_protocol.erl
@@ -33,7 +33,7 @@ notification(Method, Params) ->
              , method  => Method
              , params  => Params
              },
-  content(jsx:encode(Message)).
+  content(jsx:encode(Message, [uescape])).
 
 -spec request(number(), binary()) -> binary().
 request(RequestId, Method) ->
@@ -41,7 +41,7 @@ request(RequestId, Method) ->
              , method  => Method
              , id      => RequestId
              },
-  content(jsx:encode(Message)).
+  content(jsx:encode(Message, [uescape])).
 
 -spec request(number(), binary(), any()) -> binary().
 request(RequestId, Method, Params) ->
@@ -50,7 +50,7 @@ request(RequestId, Method, Params) ->
              , id      => RequestId
              , params  => Params
              },
-  content(jsx:encode(Message)).
+  content(jsx:encode(Message, [uescape])).
 
 -spec response(number(), any()) -> binary().
 response(RequestId, Result) ->
@@ -59,7 +59,7 @@ response(RequestId, Result) ->
              , result  => Result
              },
   ?LOG_DEBUG("[Response] [message=~p]", [Message]),
-  content(jsx:encode(Message)).
+  content(jsx:encode(Message, [uescape])).
 
 -spec error(number(), any()) -> binary().
 error(RequestId, Error) ->
@@ -68,7 +68,7 @@ error(RequestId, Error) ->
              , error   => Error
              },
   ?LOG_DEBUG("[Response] [message=~p]", [Message]),
-  content(jsx:encode(Message)).
+  content(jsx:encode(Message, [uescape])).
 
 %%==============================================================================
 %% Data Structures

--- a/apps/els_lsp/priv/code_navigation/src/format_unicode_input.erl
+++ b/apps/els_lsp/priv/code_navigation/src/format_unicode_input.erl
@@ -1,0 +1,8 @@
+-module(format_unicode_input).
+
+-export([main/1]).
+
+-spec main(any()) -> any().
+main(X) ->
+%% １２３
+    X.

--- a/apps/els_lsp/priv/code_navigation/src/format_unicode_input.erl
+++ b/apps/els_lsp/priv/code_navigation/src/format_unicode_input.erl
@@ -4,5 +4,5 @@
 
 -spec main(any()) -> any().
 main(X) ->
-%% １２３
+%% 👍😀🎉
     X.

--- a/apps/els_lsp/src/els_text_edit.erl
+++ b/apps/els_lsp/src/els_text_edit.erl
@@ -49,14 +49,14 @@ make_text_edits([{del, Del}, {ins, Ins}|T], Line, Acc) ->
     Pos1 = #{ line => Line,       character => 0 },
     Pos2 = #{ line => Line + Len, character => 0 },
     Edit = #{ range => #{ start => Pos1, 'end' => Pos2 }
-            , newText => els_utils:to_binary(lists:concat(Ins))
+            , newText => list_to_binary(Ins)
             },
     make_text_edits(T, Line + Len, [Edit|Acc]);
 
 make_text_edits([{ins, Data}|T], Line, Acc) ->
     Pos = #{ line => Line, character => 0 },
     Edit = #{ range => #{ start => Pos, 'end' => Pos }
-            , newText => els_utils:to_binary(lists:concat(Data))
+            , newText => list_to_binary(Data)
             },
     make_text_edits(T, Line, [Edit|Acc]);
 

--- a/apps/els_lsp/test/els_formatter_SUITE.erl
+++ b/apps/els_lsp/test/els_formatter_SUITE.erl
@@ -12,7 +12,8 @@
         ]).
 
 %% Test cases
--export([ format_doc/1
+-export([ format_doc/1,
+          format_unicode_doc/1
         ]).
 
 %%==============================================================================
@@ -72,6 +73,26 @@ format_doc(Config) ->
         #{newText => <<"        X.\n">>,
           range =>
             #{'end' => #{character => 0, line => 9},
+              start => #{character => 0, line => 6}}}
+       ]
+      , Result)
+  after
+    file:set_cwd(Cwd)
+  end,
+  ok.
+
+-spec format_unicode_doc(config()) -> ok.
+format_unicode_doc(Config) ->
+  {ok, Cwd} = file:get_cwd(),
+  RootPath = els_test_utils:root_path(),
+  try
+    file:set_cwd(RootPath),
+    Uri = ?config(format_unicode_input_uri, Config),
+    #{result := Result} = els_client:document_formatting(Uri, 8, true),
+    ?assertEqual(
+       [#{newText => <<"        %% １２３\n        X.\n"/utf8>>,
+          range =>
+            #{'end' => #{character => 0, line => 8},
               start => #{character => 0, line => 6}}}
        ]
       , Result)

--- a/apps/els_lsp/test/els_formatter_SUITE.erl
+++ b/apps/els_lsp/test/els_formatter_SUITE.erl
@@ -90,7 +90,7 @@ format_unicode_doc(Config) ->
     Uri = ?config(format_unicode_input_uri, Config),
     #{result := Result} = els_client:document_formatting(Uri, 8, true),
     ?assertEqual(
-       [#{newText => <<"        %% １２３\n        X.\n"/utf8>>,
+       [#{newText => <<"        %% 👍😀🎉\n        X.\n"/utf8>>,
           range =>
             #{'end' => #{character => 0, line => 8},
               start => #{character => 0, line => 6}}}


### PR DESCRIPTION
### Description

This PR makes it possible to handle non-ASCII Unicode characters when formatting code.

Related issue: https://github.com/erlang-ls/erlang_ls/issues/1236
