### PR TITLE
Use efmt as the local formatter

### DIFF
--- a/apps/els_lsp/src/efmt_formatter.erl
+++ b/apps/els_lsp/src/efmt_formatter.erl
@@ -1,0 +1,68 @@
+-module(efmt_formatter).
+
+-behaviour(rebar3_formatter).
+
+-export([init/2, format_file/3]).
+
+-include_lib("kernel/include/logger.hrl").
+
+-record(?MODULE, {}).
+
+-type state() :: #?MODULE{}.
+
+-spec init(rebar3_formatter:opts(), unused) -> state().
+init(_Opts, _) ->
+    #?MODULE{}.
+
+-spec format_file(file:filename_all(), state(), rebar3_formatter:opts()) ->
+          rebar3_formatter:result().
+format_file(File, _State, Opts) ->
+    case Opts of
+        #{action := verify} ->
+            error(not_implemented);
+        _ ->
+            Path = filename:join(filename:absname(maps:get(output_dir, Opts)), File),
+
+            ok = filelib:ensure_dir(Path),
+            {ok, _} = file:copy(File, Path),
+            case execute_command(["efmt", "--write", Path]) of
+                {ok, _} ->
+                    changed;
+                {error, Output} ->
+                    ?LOG_WARNING("[efmt] Failed to format ~p: output=~s", [File, Output]),
+                    unchanged
+            end
+    end.
+
+-spec execute_command([string()]) -> {ok | error, binary()}.
+execute_command(Args)  ->
+    case command_path() of
+        {error, Reason} ->
+            {error, Reason};
+        {ok, Path} ->
+            Port = erlang:open_port({spawn_executable, Path}, [{args, Args}, exit_status]),
+            collect_command_output(Port, [])
+    end.
+
+-spec command_path() -> {ok, string()} | {error, binary()}.
+command_path() ->
+    case os:find_executable("rebar3") of
+        false ->
+            {error, <<"rebar3 is not found">>};
+        Path ->
+            {ok, Path}
+    end.
+
+-spec collect_command_output(port(), iolist()) -> {ok | error, binary()}.
+collect_command_output(Port, Output) ->
+    receive
+        {Port, {data, Data}} ->
+            collect_command_output(Port, [Output | Data]);
+        {Port, {exit_status, 0}} ->
+            {ok, list_to_binary(Output)};
+        {Port, {exit_status, _}} ->
+            {error, list_to_binary(Output)}
+    after
+        60000 ->
+            {erorr, <<"timeout">>}
+    end.

--- a/apps/els_lsp/src/els_formatting_provider.erl
+++ b/apps/els_lsp/src/els_formatting_provider.erl
@@ -136,16 +136,9 @@ format_document_bsp(Dir, RelativePath, _Options) ->
 
 -spec format_document_local(string(), string(), formatting_options()) ->
            boolean().
-format_document_local(Dir, RelativePath,
-                      #{ <<"insertSpaces">> := InsertSpaces
-                       , <<"tabSize">> := TabSize } = Options) ->
-  SubIndent = maps:get(<<"subIndent">>, Options, ?DEFAULT_SUB_INDENT),
-  Opts = #{ remove_tabs => InsertSpaces
-          , break_indent => TabSize
-          , sub_indent => SubIndent
-          , output_dir => Dir
-          },
-  Formatter = rebar3_formatter:new(default_formatter, Opts, unused),
+format_document_local(Dir, RelativePath, _Options) ->
+  Opts = #{ output_dir => Dir },
+  Formatter = rebar3_formatter:new(efmt_formatter, Opts, unused),
   rebar3_formatter:format_file(RelativePath, Formatter),
   true.
 


### PR DESCRIPTION
This PR changes the formatter used in `els_formatting_provider.erl` from `rebar3_formatter` to [`efmt`](https://github.com/sile/efmt).